### PR TITLE
Fix Discord collaborator role change bug

### DIFF
--- a/src/app/_components/collaborators.tsx
+++ b/src/app/_components/collaborators.tsx
@@ -182,7 +182,7 @@ export function Collaborators({
 
                           if (targetValue === "_delete") {
                             deleteCollaborator.mutate({
-                              username:
+                              discord:
                                 collaborator.discord.username ?? undefined,
                               track: username,
                             });
@@ -191,8 +191,7 @@ export function Collaborators({
                           }
 
                           updateCollaborator.mutate({
-                            username:
-                              collaborator.discord.username ?? undefined,
+                            discord: collaborator.discord.username ?? undefined,
                             role:
                               targetValue === "_manager"
                                 ? "MANAGER"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Renamed parameter from `username` to `discord` in collaborator mutation calls for clarity and consistency.
  
- **Improvements**
  - Enhanced clarity in the code by aligning parameter names with the actual data being used (Discord usernames).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->